### PR TITLE
Estable con diferentes ángulos de azimuth

### DIFF
--- a/simulacion.py
+++ b/simulacion.py
@@ -10,17 +10,18 @@ import signal
 import fcntl
 import string
 import re
+import itertools
 
 import pytz
 import csv
-from time import sleep
-from datetime import datetime
-from io import StringIO
-
-# Importación de bibliotecas
 import pvlib
 import pandas as pd
 import matplotlib.pyplot as plt
+
+from time import sleep
+from datetime import datetime
+from io import StringIO
+from pvlib import solarposition
 
 glosario = {'ghi':'Radiación global Horizontal', 'dni':'Radiación directa', 'dhi':'Radiación difusa', 'IR(h)':'Índice de claridad', 'aoi':'Ángulo de incidencia', 'dni_extra':'Porcentaje de radiación extra'}
 
@@ -57,66 +58,68 @@ for location in coordinates:
 system = {'module':module, 'inversor':inverter, 'surface_azimuth':180}
 possible_azimuth = [5,180,130,310]
 energies = {}
-for orientation in possible_azimuth:
-    print("Orientación: " + str(orientation))
-    for weather in tmys:
-        location = coordinates[0]
-        latitude, longitude, name, altitude, timezone = location
-        system['surface_azimuth'] = orientation
-        system['surface_tilt']=latitude
-        solpos = pvlib.solarposition.get_solarposition(
-            time=weather.index,
-            latitude=latitude,
-            longitude=longitude,
-            altitude=altitude,
-            temperature=weather['temp_air'],
-            pressure=pvlib.atmosphere.alt2pres(altitude)
-        )
-        dni_extra = pvlib.irradiance.get_extra_radiation(weather.index)
-        airmass = pvlib.atmosphere.get_relative_airmass(solpos['apparent_zenith'])
-        pressure = pvlib.atmosphere.alt2pres(altitude)
-        am_abs = pvlib.atmosphere.get_absolute_airmass(airmass,pressure)
-        aoi = pvlib.irradiance.aoi(
-            system['surface_tilt'],
-            system['surface_azimuth'],
-            solpos['apparent_zenith'],
-            solpos['azimuth']
-        )
-        #Irradiación total general
-        total_irradiance = pvlib.irradiance.get_total_irradiance(
+for azimuth_angle in possible_azimuth:
+  for weather in tmys:
+      location = coordinates[0]
+      latitude, longitude, name, altitude, timezone = location
+      system['surface_tilt']=latitude
+      system['surface_azimuth']=azimuth_angle
+      solpos = pvlib.solarposition.get_solarposition(
+          time=weather.index,
+          latitude=latitude,
+          longitude=longitude,
+          altitude=altitude,
+          temperature=weather['temp_air'],
+          pressure=pvlib.atmosphere.alt2pres(altitude)
+      )
+      dni_extra = pvlib.irradiance.get_extra_radiation(weather.index)
+      airmass = pvlib.atmosphere.get_relative_airmass(solpos['apparent_zenith'])
+      pressure = pvlib.atmosphere.alt2pres(altitude)
+      am_abs = pvlib.atmosphere.get_absolute_airmass(airmass,pressure)
+      aoi = pvlib.irradiance.aoi(
           system['surface_tilt'],
           system['surface_azimuth'],
           solpos['apparent_zenith'],
-          solpos['azimuth'],
-          weather['dni'],
-          weather['ghi'],
-          weather['dhi'],
-          dni_extra=dni_extra,
-          model='haydavies'
-        )
-        cell_temperature = pvlib.temperature.sapm_cell(
-          total_irradiance['poa_global'],
-          weather['temp_air'],
-          weather['wind_speed'],
-          **temperature_model_parameters     
-        )
-        #Irradiación efectiva
-        effective_irradiance = pvlib.pvsystem.sapm_effective_irradiance(
-          total_irradiance['poa_direct'],
-          total_irradiance['poa_diffuse'],
-          am_abs,
-          aoi,
-          module
-        )  
-        dc=pvlib.pvsystem.sapm(effective_irradiance,cell_temperature,module)
-        ac=pvlib.inverter.sandia(dc['v_mp'],dc['p_mp'],inverter)
-        annual_energy = ac.sum()
-        energies[name] = annual_energy
+          solpos['azimuth']
+      )
+      #Irradiación total general
+      total_irradiance = pvlib.irradiance.get_total_irradiance(
+        system['surface_tilt'],
+        system['surface_azimuth'],
+        solpos['apparent_zenith'],
+        solpos['azimuth'],
+        weather['dni'],
+        weather['ghi'],
+        weather['dhi'],
+        dni_extra=dni_extra,
+        model='haydavies'
+      )
+      cell_temperature = pvlib.temperature.sapm_cell(
+        total_irradiance['poa_global'],
+        weather['temp_air'],
+        weather['wind_speed'],
+        **temperature_model_parameters     
+      )
+      #Irradiación efectiva
+      effective_irradiance = pvlib.pvsystem.sapm_effective_irradiance(
+        total_irradiance['poa_direct'],
+        total_irradiance['poa_diffuse'],
+        am_abs,
+        aoi,
+        module
+      )  
+      dc=pvlib.pvsystem.sapm(effective_irradiance,cell_temperature,module)
+      ac=pvlib.inverter.sandia(dc['v_mp'],dc['p_mp'],inverter)
+      annual_energy = ac.sum()
+      energies[azimuth_angle] = annual_energy
 
 energies = pd.Series(energies)
 
-
-
+print(energies)
+energies.plot(kind='bar',rot=0)
+plt.ylabel('Rendimiento energético Anual(Wh)')
+plt.xlabel('Ángulo Acimutal')
+plt.show()
 
 
 


### PR DESCRIPTION
Ya está estable el código que muestra los diferentes valores de rendimiento energético anual respecto a las diferentes orientaciones acimutales del panel.